### PR TITLE
kmeans: fix in-place modifications of input data

### DIFF
--- a/kmeans.lua
+++ b/kmeans.lua
@@ -26,9 +26,9 @@ function unsup.kmeans(x, k, niter, batchsize, callback, verbose)
    end
 
    -- some shortcuts
-   local sum = x.sum
-   local max = x.max
-   local pow = x.pow
+   local sum = torch.sum
+   local max = torch.max
+   local pow = torch.pow
 
    -- dims
    local nsamples = (#x)[1]


### PR DESCRIPTION
`x.pow` has for effect to modify in-place its first arg:

```Lua
local x   = torch.Tensor{1, 2, 3}
local pow = x.pow
local x2  = pow(x, 2)
print(x) --> {1, 4, 9} i.e x has been modified!
```

For consistency I also reverted to `torch.sum` and `torch.max` that have no impact vs. tensor type (see #24).