### PR TITLE
pca.lua: fix typos and minor code improvements

### DIFF
--- a/pca.lua
+++ b/pca.lua
@@ -1,10 +1,10 @@
 
 -- PCA using covariance matrix
--- x is supposed to be MxN matrix, where M samples(trials) and each sample(trial) is N dim
--- returns the eigen values and vecotrs of the covariance matrix in increasing order
+-- x is supposed to be MxN matrix, where M is the number of samples (trials) and each sample (trial) is N dim
+-- returns the eigen values and vectors of the covariance matrix in *INCREASING* order
 function unsup.pcacov(x)
    local mean = torch.mean(x,1)
-   local xm = x - torch.ger(torch.ones(x:size(1)),mean:squeeze())
+   local xm = x - mean:expandAs(x)
    local c = torch.mm(xm:t(),xm)
    c:div(x:size(1)-1)
    local ce,cv = torch.symeig(c,'V')
@@ -12,11 +12,11 @@ function unsup.pcacov(x)
 end
 
 -- PCA using SVD
--- x is supposed to be MxN matrix, where M samples(trials) and each sample(trial) is N dim
--- returns the eigen values and vecotrs of the covariance matrix in decreasing order
+-- x is supposed to be MxN matrix, where M is the number of samples (trials) and each sample (trial) is N dim
+-- returns the eigen values and vectors of the covariance matrix in decreasing order
 function unsup.pca(x)
    local mean = torch.mean(x,1)
-   local xm = x - torch.ger(torch.ones(x:size(1)),mean:squeeze())
+   local xm = x - mean:expandAs(x)
    xm:div(math.sqrt(x:size(1)-1))
    local w,s,v = torch.svd(xm:t())
    s:cmul(s)


### PR DESCRIPTION
- fix typos in comments (+ highlighting the different eigen-value return order for pcacov)
- minor code improvement
